### PR TITLE
Sorting keys of generated maps in output

### DIFF
--- a/src/javascript_externs_generator/extern.cljs
+++ b/src/javascript_externs_generator/extern.cljs
@@ -25,14 +25,14 @@
   ([obj name seen]
    {:name      name
     :type      (prop-type obj)
-    :props     (for [prop-name (js-keys obj)
+    :props     (for [prop-name (-> obj js-keys sort)
                      :let [child (obj/get obj prop-name)]]
                  (if (and (parent-type? child)
                           (not (contains? seen child))
                           (not (.-nodeType child)))
                    (generate-object-tree child prop-name (conj seen child))
                    {:name prop-name :type (prop-type child)}))
-    :prototype (for [prop-name (js-keys (.-prototype obj))]
+    :prototype (for [prop-name (-> obj .-prototype js-keys sort)]
                  {:name prop-name :type :function})}))
 
 (defn emit-props-extern
@@ -93,5 +93,3 @@
     (when (nil? js-object)
       (throw (str "Namespace '" name "' was not found. Make sure the library is loaded and the name is spelled correctly.")))
     (wrap-extern name (extract name js-object))))
-
-

--- a/test/javascript_externs_generator/extern_test.cljs
+++ b/test/javascript_externs_generator/extern_test.cljs
@@ -72,3 +72,14 @@
                     "/**********************************************************************/\n")
         expected (str header "var TEST = {};\n" footer)]
     (is (= expected output))))
+
+(deftest sorted-keys
+  (let [js-string "var TEST = {zero: 0, apple: 0, octopus: 0};"
+        expected "var TEST = {\"apple\": {},\"octopus\": {},\"zero\": {}};"]
+    (compare! expected js-string)))
+
+(deftest sorted-prototype-keys
+  (let [js-string "var TEST = {testFunction: function(){}, another: function(){}}; TEST.testFunction.prototype.testPrototypeFunction = function(){}"
+        expected "var TEST = {\"another\": function(){},\"testFunction\": function(){}};TEST.testFunction.prototype = {\"testPrototypeFunction\": function(){}};"]
+    (compare! expected js-string)))
+


### PR DESCRIPTION
This has no computational value since javascript map keys are unsorted, but it should make diffs between different generated externs a little easier to read.